### PR TITLE
fix: eliminate false-positive failover for transient rate limits

### DIFF
--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ function collectErrorDetails(error) {
   return { text: texts.join(" "), statusCode };
 }
 
-function isUsageLimitError(error) {
+function isDefinitiveQuotaError(error) {
   const { text, statusCode } = collectErrorDetails(error);
   if (!text) {
     return false;
@@ -349,10 +349,6 @@ function isUsageLimitError(error) {
     return true;
   }
 
-  if (/(would exceed your account'?s rate limit|account'?s rate limit)/.test(text)) {
-    return true;
-  }
-
   if (statusCode === 402) {
     const billingWords = /(payment|billing|quota|credit|subscription|plan)/;
     if (billingWords.test(text)) {
@@ -367,6 +363,36 @@ function isUsageLimitError(error) {
   }
 
   return false;
+}
+
+function isAmbiguousRateLimitSignal(error) {
+  const { text } = collectErrorDetails(error);
+  if (!text) {
+    return false;
+  }
+
+  const tokenLimitSignals = [
+    "context length",
+    "context window",
+    "token limit",
+    "too many tokens",
+    "prompt is too long",
+    "max_tokens",
+    "context_length_exceeded"
+  ];
+  if (tokenLimitSignals.some((signal) => text.includes(signal))) {
+    return false;
+  }
+
+  if (/(would exceed your account'?s rate limit|account'?s rate limit)/.test(text)) {
+    return true;
+  }
+
+  return false;
+}
+
+function isUsageLimitError(error) {
+  return isDefinitiveQuotaError(error) || isAmbiguousRateLimitSignal(error);
 }
 
 function isBedrockOpusModel(model) {
@@ -398,8 +424,11 @@ function isThinkingBlockMutationError(error) {
   return hits >= 2;
 }
 
-function shouldTriggerFailover(error, failedModel) {
-  if (isUsageLimitError(error)) {
+function shouldTriggerFailover(error, failedModel, { requireDefinitive = false } = {}) {
+  const isQuota = requireDefinitive
+    ? isDefinitiveQuotaError(error)
+    : isUsageLimitError(error);
+  if (isQuota) {
     return true;
   }
 
@@ -1185,7 +1214,7 @@ function buildStatusReport(sessionID) {
   return lines.join("\n");
 }
 
-export { isUsageLimitError };
+export { isUsageLimitError, isDefinitiveQuotaError, isAmbiguousRateLimitSignal };
 
 export default async function quotaFailoverPlugin(ctx) {
   resetRuntimeSettings();
@@ -1430,7 +1459,7 @@ export default async function quotaFailoverPlugin(ctx) {
             providerID: info.providerID,
             modelID: info.modelID
           };
-          if (!info.error || !shouldTriggerFailover(info.error, failedModel)) {
+          if (!info.error || !shouldTriggerFailover(info.error, failedModel, { requireDefinitive: true })) {
             return;
           }
 
@@ -1509,7 +1538,7 @@ export default async function quotaFailoverPlugin(ctx) {
           const failedModel = (lastAssistant?.providerID && lastAssistant?.modelID)
             ? { providerID: lastAssistant.providerID, modelID: lastAssistant.modelID }
             : null;
-          if (!sessionID || !error || !shouldTriggerFailover(error, failedModel)) {
+          if (!sessionID || !error || !shouldTriggerFailover(error, failedModel, { requireDefinitive: true })) {
             return;
           }
 

--- a/index.test.js
+++ b/index.test.js
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
-import quotaFailoverPlugin, { isUsageLimitError } from "./index.js";
+import quotaFailoverPlugin, { isUsageLimitError, isDefinitiveQuotaError, isAmbiguousRateLimitSignal } from "./index.js";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -1764,6 +1764,238 @@ describe("opencode-quota-failover", () => {
       expect(isUsageLimitError({
         data: { message: "Rate limit reached. Please retry in 1 minute. Limit: 100 RPM", statusCode: 429 }
       })).toBe(false);
+    });
+  });
+
+  describe("isDefinitiveQuotaError - hard quota only", () => {
+    test.each([
+      ["insufficient_quota"],
+      ["You exceeded your current quota, please check your plan and billing details."],
+      ["quota exceeded for this billing period"],
+      ["billing hard limit reached"],
+      ["out of credits"],
+      ["insufficient credits for this request"],
+      ["servicequotaexceeded"],
+      ["you have reached your usage limit"],
+      ["monthly usage limit exceeded"],
+      ["daily usage limit reached"],
+      ["your subscription limit has been reached"],
+      ["plan limit reached"],
+      ["usage limit exceeded for your account"],
+    ])("returns true for definitive quota: %s", (message) => {
+      expect(isDefinitiveQuotaError({ message })).toBe(true);
+    });
+
+    test("returns true for HTTP 402 + billing language", () => {
+      expect(isDefinitiveQuotaError({
+        data: { message: "Payment required: upgrade your billing plan", statusCode: 402 }
+      })).toBe(true);
+    });
+
+    test("returns true for long backoff + account words in error text", () => {
+      expect(isDefinitiveQuotaError({
+        message: "This request would exceed your account's rate limit. Please try again later. [retrying in 1h 39m]"
+      })).toBe(true);
+    });
+
+    test("returns false for 'account rate limit' WITHOUT long backoff in text", () => {
+      expect(isDefinitiveQuotaError({
+        message: "This request would exceed your account's rate limit. Please try again later."
+      })).toBe(false);
+    });
+
+    test("returns false for transient rate limit", () => {
+      expect(isDefinitiveQuotaError({ message: "rate limit exceeded, retry in 30 seconds" })).toBe(false);
+    });
+
+    test("returns false for generic too many requests", () => {
+      expect(isDefinitiveQuotaError({ message: "too many requests" })).toBe(false);
+    });
+
+    test("returns false for context length errors", () => {
+      expect(isDefinitiveQuotaError({ message: "context length exceeded" })).toBe(false);
+    });
+
+    test("returns false for server overloaded", () => {
+      expect(isDefinitiveQuotaError({ message: "overloaded_error: temporarily unable to process" })).toBe(false);
+    });
+  });
+
+  describe("isAmbiguousRateLimitSignal - deferred to session.status", () => {
+    test("returns true for 'would exceed account rate limit'", () => {
+      expect(isAmbiguousRateLimitSignal({
+        message: "This request would exceed your account's rate limit. Please try again later."
+      })).toBe(true);
+    });
+
+    test("returns true for 'accounts rate limit' without apostrophe", () => {
+      expect(isAmbiguousRateLimitSignal({
+        message: "accounts rate limit exceeded"
+      })).toBe(true);
+    });
+
+    test("returns false for generic rate limit without account qualifier", () => {
+      expect(isAmbiguousRateLimitSignal({ message: "rate limit exceeded" })).toBe(false);
+    });
+
+    test("returns false for hard quota patterns", () => {
+      expect(isAmbiguousRateLimitSignal({ message: "insufficient_quota" })).toBe(false);
+    });
+
+    test("returns false for context length errors", () => {
+      expect(isAmbiguousRateLimitSignal({ message: "context length exceeded" })).toBe(false);
+    });
+
+    test("returns false for too many requests", () => {
+      expect(isAmbiguousRateLimitSignal({ message: "too many requests" })).toBe(false);
+    });
+  });
+
+  test("message.updated does NOT trigger failover for ambiguous 'account rate limit' without backoff", async () => {
+    const sessionID = "s-no-false-positive";
+    const messagesBySession = {
+      [sessionID]: [
+        makeUserMessage(sessionID, {
+          id: "u-no-false-positive",
+          agent: "sisyphus",
+          providerID: "anthropic",
+          modelID: "claude-opus-4-6"
+        }),
+        makeAssistantErrorMessage(
+          sessionID,
+          "anthropic",
+          "claude-opus-4-6",
+          "This request would exceed your account's rate limit. Please try again later.",
+          429
+        )
+      ]
+    };
+    const { ctx, promptCalls } = createContext(messagesBySession);
+    const hooks = await quotaFailoverPlugin(ctx);
+
+    await hooks.event({
+      event: {
+        type: "message.updated",
+        properties: { info: messagesBySession[sessionID][1].info }
+      }
+    });
+    await hooks.event({
+      event: { type: "session.idle", properties: { sessionID } }
+    });
+
+    expect(promptCalls).toHaveLength(0);
+  });
+
+  test("session.error does NOT trigger failover for ambiguous 'account rate limit' without backoff", async () => {
+    const sessionID = "s-error-no-false-positive";
+    const messagesBySession = {
+      [sessionID]: [
+        makeUserMessage(sessionID, {
+          id: "u-error-no-fp",
+          agent: "sisyphus",
+          providerID: "anthropic",
+          modelID: "claude-opus-4-6"
+        }),
+        makeAssistantErrorMessage(sessionID, "anthropic", "claude-opus-4-6", "noop", 200)
+      ]
+    };
+    const { ctx, promptCalls } = createContext(messagesBySession);
+    const hooks = await quotaFailoverPlugin(ctx);
+
+    await hooks.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            sessionID, role: "assistant",
+            providerID: "anthropic", modelID: "claude-opus-4-6",
+            tokens: { input: 1000, output: 0 }
+          }
+        }
+      }
+    });
+
+    await hooks.event({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          error: { message: "This request would exceed your account's rate limit. Please try again later." }
+        }
+      }
+    });
+    await hooks.event({
+      event: { type: "session.idle", properties: { sessionID } }
+    });
+
+    expect(promptCalls).toHaveLength(0);
+  });
+
+  test("message.updated STILL triggers immediately for definitive quota (insufficient_quota)", async () => {
+    const sessionID = "s-definitive-still-works";
+    const messagesBySession = {
+      [sessionID]: [
+        makeUserMessage(sessionID, {
+          id: "u-definitive",
+          agent: "sisyphus",
+          providerID: "anthropic",
+          modelID: "claude-opus-4-6"
+        }),
+        makeAssistantErrorMessage(sessionID, "anthropic", "claude-opus-4-6", "insufficient_quota")
+      ]
+    };
+    const { ctx, promptCalls } = createContext(messagesBySession);
+    const hooks = await quotaFailoverPlugin(ctx);
+
+    await hooks.event({
+      event: {
+        type: "message.updated",
+        properties: { info: messagesBySession[sessionID][1].info }
+      }
+    });
+    await hooks.event({
+      event: { type: "session.idle", properties: { sessionID } }
+    });
+
+    expect(promptCalls).toHaveLength(1);
+  });
+
+  test("message.updated STILL triggers when 'account rate limit' includes long backoff in error text", async () => {
+    const sessionID = "s-account-rl-long-backoff-text";
+    const messagesBySession = {
+      [sessionID]: [
+        makeUserMessage(sessionID, {
+          id: "u-rl-long-backoff-text",
+          agent: "sisyphus",
+          providerID: "anthropic",
+          modelID: "claude-opus-4-6"
+        }),
+        makeAssistantErrorMessage(
+          sessionID,
+          "anthropic",
+          "claude-opus-4-6",
+          "This request would exceed your account's rate limit. Please try again later. [retrying in 1h 39m]",
+          429
+        )
+      ]
+    };
+    const { ctx, promptCalls } = createContext(messagesBySession);
+    const hooks = await quotaFailoverPlugin(ctx);
+
+    await hooks.event({
+      event: {
+        type: "message.updated",
+        properties: { info: messagesBySession[sessionID][1].info }
+      }
+    });
+    await hooks.event({
+      event: { type: "session.idle", properties: { sessionID } }
+    });
+
+    expect(promptCalls).toHaveLength(1);
+    expect(promptCalls[0].body.model).toEqual({
+      providerID: "amazon-bedrock",
+      modelID: "us.anthropic.claude-opus-4-6-v1"
     });
   });
 


### PR DESCRIPTION
## Summary

- **Splits `isUsageLimitError()` into two-tier classification**: `isDefinitiveQuotaError()` (hard quota signals that always trigger) and `isAmbiguousRateLimitSignal()` ("account's rate limit" that could be transient)
- **Updates `message.updated` and `session.error` handlers** to only trigger failover on definitive quota signals (`requireDefinitive: true`), preventing false-positive provider switches on transient per-minute rate limits
- **Preserves `session.status` handler behavior** unchanged — it already correctly gates on backoff duration >= 30 min

## Problem

The plugin was incorrectly classifying transient per-minute rate limits as permanent quota exhaustion. When a provider returned "would exceed your account's rate limit" (a temporary burst throttle), the `message.updated` handler matched it unconditionally and triggered failover — switching subagents to a different provider unnecessarily. The platform's built-in retry mechanism would have resolved the transient limit in 1-5 minutes.

## Fix

Two classes of errors now have different handling:

| Error Type | Example | `message.updated` / `session.error` | `session.status` |
|---|---|---|---|
| **Definitive quota** | `insufficient_quota`, `billing_hard_limit`, HTTP 402 | Triggers immediately | Triggers (with backoff check) |
| **Ambiguous rate limit** | `"account's rate limit"` without long backoff | **Deferred** (no trigger) | Triggers if backoff >= 30min |

## Test Coverage

- 96 tests pass, 0 failures (was 66 before)
- +30 new tests covering `isDefinitiveQuotaError`, `isAmbiguousRateLimitSignal`, integration tests for false-positive prevention, and regression tests for definitive quota still triggering